### PR TITLE
Drop Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,13 @@
 language: python
 
 python:
-  - 2.7
   - 3.3
   - 3.4
   - 3.5
-
-matrix:
-  include:
-    - python: 2.7
-    - FLASK="<0.10"
+  - 3.6
 
 install:
-  - pip install flask$FLASK
+  - pip install flask
   - pip install pytest coverage coveralls
   - python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
Tests have never worked for 2.7 and it's not something I've used this with.