### PR TITLE
Use ClauseElement.__str__() instead of str() to obtain statement

### DIFF
--- a/flask_sqlalchemy_caching/core.py
+++ b/flask_sqlalchemy_caching/core.py
@@ -129,7 +129,7 @@ class CachingQuery(BaseQuery):
         particular Query, then combining that with the bound parameter values.
         """
         stmt = self.with_labels().statement
-        key = str(stmt.compile(compile_kwargs={'literal_binds': True}))
+        key = stmt.compile(compile_kwargs={'literal_binds': True}).__str__()
         return md5(key.encode('utf8')).hexdigest()
 
 


### PR DESCRIPTION
When a field value is a unicode string, the use of `str()` in python 2.x will fail. Python 3.x does not have a `unicode()` function, however SQLAlchemy does have `__str__()` which will encode between py2 and py3:

https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/sql/elements.py#L489
