### PR TITLE
BaseQuery was renamed to Query

### DIFF
--- a/flask_sqlalchemy_caching/core.py
+++ b/flask_sqlalchemy_caching/core.py
@@ -11,7 +11,10 @@ import time
 from hashlib import md5
 
 from sqlalchemy.orm.interfaces import MapperOption
-from flask_sqlalchemy.query import Query as BaseQuery
+try:
+    from flask_sqlalchemy import BaseQuery
+except ImportError:
+    from flask_sqlalchemy.query import Query as BaseQuery
 
 
 class CachingQuery(BaseQuery):

--- a/flask_sqlalchemy_caching/core.py
+++ b/flask_sqlalchemy_caching/core.py
@@ -11,7 +11,7 @@ import time
 from hashlib import md5
 
 from sqlalchemy.orm.interfaces import MapperOption
-from flask_sqlalchemy import BaseQuery
+from flask_sqlalchemy.query import Query as BaseQuery
 
 
 class CachingQuery(BaseQuery):


### PR DESCRIPTION
In [Flask-SQLAlchemy v3.0.0](https://github.com/pallets-eco/flask-sqlalchemy/blob/main/CHANGES.rst#version-300).